### PR TITLE
fix: correct spelling in comments

### DIFF
--- a/Development/Development.bac
+++ b/Development/Development.bac
@@ -23,8 +23,8 @@
 #' @param passAllFunctions Logical; if TRUE, all global functions are passed on, otherwise only those in input.functions.
 #' @param input.functions A character vector of global function names to be passed on if passAllFunctions is FALSE.
 #' @param returnEnv Logical; if TRUE, assigns the script environment to the global environment.
-#' @param removeBigObjs Logical; if TRUE, cleans the script environment from big objects, and return the remaing env to the global environment.
-#' @param max.size a numeric value specifying the maximum size of an objects to keep in the env, in bytes. Default =1e6 (1MB).
+#' @param removeBigObjs Logical; if TRUE, cleans the script environment from big objects and returns the remaining environment to the global environment.
+#' @param max.size a numeric value specifying the maximum size of an object to keep in the env, in bytes. Default =1e6 (1MB).
 #' @param ... Arguments to pass on to source()
 #' @return No return value, the function returns variables into the .GlobalEnv.
 #' @export
@@ -66,7 +66,7 @@ sourceClean <- function(
     )
   }
 
-  # Create new environment that does not see .GlobalEnv (not it's parent)/
+  # Create a new environment that does not see .GlobalEnv (not its parent)
   myEnv <- new.env(parent = baseenv())
 
   # Copy specified global variables to myEnv

--- a/Development/Development.bacFALSE
+++ b/Development/Development.bacFALSE
@@ -60,7 +60,7 @@ sourceClean <- function(path, input.variables, output.variables
               , '\nSkipped.\n')
   }
 
-  # Create new environment that does not see .GlobalEnv (not it's parent)/
+  # Create a new environment that does not see .GlobalEnv (not its parent)
   myEnv <- new.env(parent = baseenv())
 
   # Copy specified global variables to myEnv

--- a/Development/Playground/01.dev.Global.R
+++ b/Development/Playground/01.dev.Global.R
@@ -52,9 +52,10 @@ z
 
 
 
-write an R function that takes a char vec of object names, and checks if they correspond to variables or functions?
-  gives warning() with the name of funcitons and return the list of variable.names()
-use camelcase. make roxygen
+# Write an R function that takes a character vector of object names and checks
+# if they correspond to variables or functions. It gives a warning with the
+# name of functions and returns the list of variable names.
+# Use camelCase. Make roxygen
 
 x <- 4
 fff <- function(x) x^3

--- a/Development/Playground/junkyard.R
+++ b/Development/Playground/junkyard.R
@@ -16,7 +16,7 @@ sourceClean <- function(path, input.variables, output.variables
 
   checkVars(input.variables, envir =  globalenv())
 
-  # Create new environment that does not see .GlobalEnv (not it's parent)/
+    # Create a new environment that does not see .GlobalEnv (not its parent)
   myEnv <- new.env(parent = baseenv())
 
   # Copy specified global variables to myEnv

--- a/R/isoENV.R
+++ b/R/isoENV.R
@@ -30,8 +30,8 @@
 #' @param packages.load Additional custom packages to load into the script's namespace.
 #' @param returnEnv Logical; if TRUE, assigns the script environment to the global environment.
 #' @param removeBigObjs Logical; if TRUE, cleans the script environment from big objects, and
-#' return the remaing env to the global environment.
-#' @param max.size a numeric value specifying the maximum size of an objects to keep in the env,
+#' returns the remaining environment to the global environment.
+#' @param max.size a numeric value specifying the maximum size of an object to keep in the env,
 #' in bytes. Default =1e6 (1MB).
 #' @param ... Arguments to pass on to source()
 #' @return No return value, the function returns variables into the .GlobalEnv.
@@ -95,7 +95,7 @@ sourceClean <- function(
     )
   }
 
-  # Create new environment that do,es not see .GlobalEnv (not it's parent).
+  # Create a new environment that does not see .GlobalEnv (not its parent).
   myEnv <- new.env(parent = baseenv())
 
   # Copy specified global variables to myEnv
@@ -330,7 +330,7 @@ checkVars <- function(
 #'
 #' @description This function removes objects from the specified environment that exceed a certain size.
 #' @param env an environment from which large objects should be removed.
-#' @param max.size a numeric value specifying the maximum size of an objects to keep in the env, in bytes.
+#' @param max.size a numeric value specifying the maximum size of an object to keep in the env, in bytes.
 #' @return The modified environment with large objects removed.
 #' @examples
 #' env <- new.env()

--- a/R/isoENV.other.R
+++ b/R/isoENV.other.R
@@ -1,5 +1,5 @@
 # ____________________________________________________________________
-# isoENV.other.R  contains funcitons not used for now  ----
+# isoENV.other.R  contains functions not used for now  ----
 # ____________________________________________________________________
 # devtools::load_all("~/GitHub/Packages/isoENV"); devtools::document("~/GitHub/Packages/isoENV")
 # try(source("~/GitHub/Packages/isoENV/R/isoENV.other.R"), silent = TRUE)

--- a/man/dot-removeBigObjsFromEnv.Rd
+++ b/man/dot-removeBigObjsFromEnv.Rd
@@ -9,7 +9,7 @@
 \arguments{
 \item{env}{an environment from which large objects should be removed.}
 
-\item{max.size}{a numeric value specifying the maximum size of an objects to keep in the env, in bytes.}
+\item{max.size}{a numeric value specifying the maximum size of an object to keep in the env, in bytes.}
 }
 \value{
 The modified environment with large objects removed.

--- a/man/sourceClean.Rd
+++ b/man/sourceClean.Rd
@@ -40,10 +40,10 @@ those in input.functions.}
 
 \item{returnEnv}{Logical; if TRUE, assigns the script environment to the global environment.}
 
-\item{removeBigObjs}{Logical; if TRUE, cleans the script environment from big objects, and
-return the remaing env to the global environment.}
+\item{removeBigObjs}{Logical; if TRUE, cleans the script environment from big objects and
+returns the remaining environment to the global environment.}
 
-\item{max.size}{a numeric value specifying the maximum size of an objects to keep in the env,
+\item{max.size}{a numeric value specifying the maximum size of an object to keep in the env,
 in bytes. Default =1e6 (1MB).}
 
 \item{...}{Arguments to pass on to source()}


### PR DESCRIPTION
## Summary
- Clean up comment grammar and spelling in core environment functions.
- Fix misspellings in auxiliary R scripts and documentation.

## Testing
- `R -q -e 'devtools::test()'` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6893381414d8832cb8703eb2e07b4db7