### PR TITLE
Fix typos in supplementary scripts

### DIFF
--- a/Development/Playground/01.dev.Global.R
+++ b/Development/Playground/01.dev.Global.R
@@ -53,7 +53,7 @@ z
 
 
 write an R function that takes a char vec of object names, and checks if they correspond to variables or functions?
-  gives warning() with the name of funcitons and return the list of variable.names()
+  gives warning() with the name of functions and returns the list of variable.names()
 use camelcase. make roxygen
 
 x <- 4

--- a/R/isoENV.other.R
+++ b/R/isoENV.other.R
@@ -1,5 +1,5 @@
 # ____________________________________________________________________
-# isoENV.other.R  contains funcitons not used for now  ----
+# isoENV.other.R  contains functions not used for now  ----
 # ____________________________________________________________________
 # devtools::load_all("~/GitHub/Packages/isoENV"); devtools::document("~/GitHub/Packages/isoENV")
 # try(source("~/GitHub/Packages/isoENV/R/isoENV.other.R"), silent = TRUE)


### PR DESCRIPTION
## Summary
- fix typos in isoENV.other.R comment
- fix typos in development playground script

## Testing
- `R -q -e 'devtools::test()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68933a00986c832c8a836c00dab84ba6