### PR TITLE
Fix spelling mistakes

### DIFF
--- a/Development/Development.bac
+++ b/Development/Development.bac
@@ -23,7 +23,7 @@
 #' @param passAllFunctions Logical; if TRUE, all global functions are passed on, otherwise only those in input.functions.
 #' @param input.functions A character vector of global function names to be passed on if passAllFunctions is FALSE.
 #' @param returnEnv Logical; if TRUE, assigns the script environment to the global environment.
-#' @param removeBigObjs Logical; if TRUE, cleans the script environment from big objects, and return the remaing env to the global environment.
+#' @param removeBigObjs Logical; if TRUE, cleans the script environment from big objects, and return the remaining env to the global environment.
 #' @param max.size a numeric value specifying the maximum size of an objects to keep in the env, in bytes. Default =1e6 (1MB).
 #' @param ... Arguments to pass on to source()
 #' @return No return value, the function returns variables into the .GlobalEnv.
@@ -66,7 +66,7 @@ sourceClean <- function(
     )
   }
 
-  # Create new environment that does not see .GlobalEnv (not it's parent)/
+  # Create new environment that does not see .GlobalEnv (not its parent)/
   myEnv <- new.env(parent = baseenv())
 
   # Copy specified global variables to myEnv
@@ -160,7 +160,7 @@ sourceClean <- function(
 #' @param variables A character vector of variable names to check.
 #' @param envir The environment in which to look for the variables.
 #' @param verbose Report on good (passing) variables.
-#' @param suffix Suffix to append to printed summary statment.
+#' @param suffix Suffix to append to printed summary statement.
 #' @return No return value, called for side effects.
 #' @examples
 #' myEnv <- new.env()

--- a/Development/Development.bacFALSE
+++ b/Development/Development.bacFALSE
@@ -60,7 +60,7 @@ sourceClean <- function(path, input.variables, output.variables
               , '\nSkipped.\n')
   }
 
-  # Create new environment that does not see .GlobalEnv (not it's parent)/
+  # Create new environment that does not see .GlobalEnv (not its parent)/
   myEnv <- new.env(parent = baseenv())
 
   # Copy specified global variables to myEnv
@@ -150,7 +150,7 @@ sourceClean <- function(path, input.variables, output.variables
 #' @param variables A character vector of variable names to check.
 #' @param envir The environment in which to look for the variables.
 #' @param verbose Report on good (passing) variables.
-#' @param suffix Suffix to append to printed summary statment.
+#' @param suffix Suffix to append to printed summary statement.
 #' @return No return value, called for side effects.
 #' @examples
 #' myEnv <- new.env()

--- a/Development/Playground/junkyard.R
+++ b/Development/Playground/junkyard.R
@@ -16,7 +16,7 @@ sourceClean <- function(path, input.variables, output.variables
 
   checkVars(input.variables, envir =  globalenv())
 
-  # Create new environment that does not see .GlobalEnv (not it's parent)/
+  # Create new environment that does not see .GlobalEnv (not its parent)/
   myEnv <- new.env(parent = baseenv())
 
   # Copy specified global variables to myEnv

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This is useful when with large objects (such as single-cell objects), by avoidin
 
 Bioinformatics workflows are traditionally split into two paradigms: the classic pipeline and the interactive session. 
 
-The classic bioinformatics pipeline calls tools after each other with clearly defined file inputs and parameters. This can be via a mother-bash file, or pipeline managers like snakeMake or NextFlow. 
+The classic bioinformatics pipeline calls tools after each other with clearly defined file inputs and parameters. This can be via a mother-bash file, or pipeline managers like Snakemake or NextFlow. 
 
 ```shell
 # mother.script.sh
@@ -32,7 +32,7 @@ tool3 -in=OutPut2 -p=Parameters3 -out=OutPut3
 # ... etc
 ```
 
-The other typical case is a completely funcionalized pipeline in an interactive session. `Seurat` for single-cell analysis is a typical example. It relies on each step written as a function.
+The other typical case is a completely functionalized pipeline in an interactive session. `Seurat` for single-cell analysis is a typical example. It relies on each step written as a function.
 
 ```R
 # interactive.analysis.R


### PR DESCRIPTION
## Summary
- Correct typos in README around Snakemake and functionalized pipeline description
- Fix spelling in development helper scripts (`remaining`, `its parent`, `statement`)

## Testing
- `R -q -e 'devtools::test()'` *(fails: R missing)*
- `apt-get install -y r-base` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68948c111054832c96b357a45a785ddc